### PR TITLE
fix censorship

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -48,14 +48,11 @@ function getRedTweets(){
 
 	function censorship(textToCensor){
 		for (i=0;i<bannedStuff.length-1;i++){
-			if (textToCensor.search(bannedStuff[i]) > 0){
+			if (textToCensor.search(bannedStuff[i]) >= 0){
 				return false;
-			} else if (!textToCensor.search(/@/g)){
-				return false;
-			} else {
-				return true;
 			}
 		}
+		return true;
 	}
 
 	function gotData(err, data, response){


### PR DESCRIPTION
we need to change the first condition to be >= 0, because 0 represents
the first position in the array, and -1 represents not in the array, so
it was incorrectly letting things through if they were the first
position.

we no longer need the second condition, because it is redundant, since
'@' is already in the array to censor

if we return true in an else block, then we ALWAYS return in the first
iteration of the for loop, and so we never check any censorship elements
except the first. Instead, we need to only return true if we've iterated
through the entire for loop and not found anything objectionable
